### PR TITLE
Move pin configuration to YAML

### DIFF
--- a/esphome/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
+++ b/esphome/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
@@ -528,7 +528,9 @@ void mhi_ac_ctrl_core_init(const Config& config) {
         .counter_dir = TIMER_COUNT_UP,
         .auto_reload = TIMER_AUTORELOAD_DIS,
         .divider = TIMER_DIVIDER,
+        #if SOC_TIMER_GROUP_SUPPORT_XTAL
         .clk_src = TIMER_SRC_CLK_APB
+        #endif    
     };
     timer_init(TIMER_GROUP_0, TIMER_0, &timer_config);
 

--- a/esphome/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
+++ b/esphome/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
@@ -39,6 +39,13 @@
 
 #define MHI_NUM_FRAMES_PER_INTERVAL 20              // every 20 frames, MISO_frame[DB14] bit2 toggles
 
+#ifndef MIN
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#endif
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
 namespace mhi_ac {
 
 enum class ACPower {


### PR DESCRIPTION
Added optional yaml config to override the pins. Default config is what used to be hard coded to maintain backwards compatibility with old configurations. 

I'm not a programmer, my code is probably janky af but it works.