### PR TITLE
Add framework_version and esp-idf version

### DIFF
--- a/esphome/example.yaml
+++ b/esphome/example.yaml
@@ -17,6 +17,8 @@ esp32:
   board: esp32-c3-devkitm-1
   framework:
     type: esp-idf
+    version: 4.4.5
+    platform_version: 5.4.0
 
 # Enable logging
 logger:


### PR DESCRIPTION
ESPHome 2024.12 has a breaking change updating ESP-IDF to version 5.1.5 which is not compatible with the code in this project.
Adding framework_version 5.4.0 and esp-idf version 4.4.5 as a workaround.
Some refactoring will be required to make it work in version 5.1.5 (mostly timer related)