### PR TITLE
Change timer clock source to default

### DIFF
--- a/esphome/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
+++ b/esphome/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
@@ -603,7 +603,7 @@ InitError init(const Config& config) {
 
     // Set up timer
     gptimer_config_t timer_config = {
-      .clk_src = GPTIMER_CLK_SRC_APB,
+      .clk_src = GPTIMER_CLK_SRC_DEFAULT,
       .direction = GPTIMER_COUNT_UP,
       .resolution_hz = 1000000, // Plenty of resolution to encode a rough 20ms ;)
     };


### PR DESCRIPTION
This allows compilation for ESP32-C6 that does not have explicit APB slock source (GPTIMER_CLK_SRC_APB) in ESP-IDF headers. According to ESP-IDF documentation should also work on ESP32-C3, but currently I do not have any C3 boards to check, so it is untested.

Tested to work with following:
- Waveshare ESP32-C6 Zero board (https://www.waveshare.com/wiki/ESP32-C6-Zero)
- Mitsubishi Heavy SSR50ZM-S (built-in duct AC)
- ESPHome 2025.11.2

Configuration (important parts):
```
esp32:
  board: esp32-c6-devkitc-1
  framework:
    type: esp-idf

MhiAcCtrl:
  id: ${mhi_device_id}
  use_long_frame: false
  mosi_pin: GPIO1
  miso_pin: GPIO4
  sclk_pin: GPIO0
  cs_in_pin: GPIO22
  cs_out_pin: GPIO21
```